### PR TITLE
Fix parse marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 0.6.1 (2020-06-03)
+
+##### Bug Fixes
+
+*  fix: return undefined when no description on field ([bdafde6](https://github.com/aerogear/graphql-metadata/commit/bdafde62145af5406f7e9fdb31a4045c0bcf4cfa))
+
 #### 0.6.0 (2020-06-03)
 
 ##### Build System / Dependencies

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "prepublishOnly": "yarn run test:all"
   },
   "dependencies": {
+    "chalk": "4.0.0",
     "graphql": "15.0.0",
-    "safe-eval": "^0.4.1"
+    "safe-eval": "0.4.1"
   },
   "devDependencies": {
     "@types/jest": "^25.2.3",
@@ -36,8 +37,8 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-node": "^8.0.1",
     "jest": "26.0.1",
-    "ts-jest": "26.0.0",
     "rimraf": "3.0.2",
+    "ts-jest": "26.0.0",
     "typescript": "^3.9.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-metadata",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Annotate a GraphQL Schema",
   "author": "Enda Phelan <ephelan@redhat.com>",
   "license": "MIT",

--- a/src/annotations/parseAnnotations.ts
+++ b/src/annotations/parseAnnotations.ts
@@ -1,4 +1,6 @@
 import safeEval from 'safe-eval'
+import chalk from 'chalk'
+
 
 /**
  * Parse annotations
@@ -13,7 +15,10 @@ import safeEval from 'safe-eval'
  * @deprecated This method is deprecated and will be removed in a future release. Please use `parseMetadata`
  */
 export function parseAnnotations (namespace: string, description: string) {
-  console.warn('WARNING! This method is deprecated and will be removed in a future release. Please use `parseMetadata`.')
+  console.warn(`${chalk.yellow('WARNING!')} ${chalk.cyan('parseAnnotations')} method is deprecated and will be removed in a future release. Please use ${chalk.cyan('parseMetadata')}.
+
+See ${chalk.blue('https://github.com/aerogear/graphql-metadata#metadata-parsing')}
+`)
 
   if (description) {
     const start = `@${namespace}`

--- a/src/annotations/parseMarker.ts
+++ b/src/annotations/parseMarker.ts
@@ -1,5 +1,7 @@
 import safeEval from 'safe-eval'
 import { TypeOrDescription } from 'src/definitions'
+import { getDescription } from '../util/getDescription';
+import Maybe from 'graphql/tsutils/Maybe';
 
 /**
  * Parse marker annotations.
@@ -14,12 +16,10 @@ import { TypeOrDescription } from 'src/definitions'
  * @param {TypeOrDescription|string} description
  * @returns {object}
  */
-export function parseMarker(marker: string, definition: TypeOrDescription): any | boolean {
-  let description: string;
-  if (typeof definition === "string") {
-    description = definition;
-  } else {
-    description = definition.description
+export function parseMarker(marker: string, definition: Maybe<TypeOrDescription>): any | boolean {
+  const description = getDescription(definition)
+  if (!description) {
+    return undefined
   }
 
   if (description) {

--- a/src/annotations/parseMetadata.ts
+++ b/src/annotations/parseMetadata.ts
@@ -1,5 +1,7 @@
 import safeEval from 'safe-eval'
 import { TypeDefinition } from 'src/definitions'
+import Maybe from 'graphql/tsutils/Maybe'
+import { getDescription } from '../util/getDescription'
 
 /**
  * Parse metadata annotations.
@@ -15,8 +17,8 @@ import { TypeDefinition } from 'src/definitions'
  * @param {TypeDefinition|string?} definition The GraphQL definition which has the metadata to be parsed
  * @returns {any|boolean}
  */
-export function parseMetadata(name: string, definition: TypeDefinition): any | boolean {
-  const description = definition.description
+export function parseMetadata(name: string, definition: Maybe<TypeDefinition>): any | boolean {
+  const description = getDescription(definition)
 
   if (description) {
     const start = `@${name}`

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,5 +1,7 @@
 import { GraphQLField, GraphQLObjectType, GraphQLEnumType, GraphQLInputField, GraphQLInputObjectType, GraphQLEnumValue, GraphQLInterfaceType, GraphQLScalarType, GraphQLArgument, GraphQLUnionType } from 'graphql'
 
+export type Maybe<T> = T | undefined;
+
 export type TypeDefinition =
   | GraphQLField<any, any>
   | GraphQLScalarType

--- a/src/util/getDescription.ts
+++ b/src/util/getDescription.ts
@@ -1,0 +1,20 @@
+import { TypeOrDescription } from '../definitions'
+import Maybe from 'graphql/tsutils/Maybe';
+
+/**
+ * Helper to extract the description value from a possible GraphQL type
+ *
+ * @param definition GraphQL type or string description
+ */
+export function getDescription(definition: Maybe<TypeOrDescription>): string | undefined {
+  let description: string;
+  if (!definition) {
+    return undefined
+  } else if (typeof definition === "string") {
+    description = definition;
+  } else {
+    description = definition.description
+  }
+
+  return description
+}

--- a/tests/specs/annotations.ts
+++ b/tests/specs/annotations.ts
@@ -28,6 +28,9 @@ test('parseMarker tests', () => {
     @marker`)
   expect(result).toBeTruthy()
 
+  result = parseMarker('marker', undefined)
+  expect(result).toEqual(undefined)
+
   result = parseMarker('marker', `
   This is a description
   @marker size:1, data:'test'`)
@@ -40,7 +43,7 @@ test('parseMarker tests', () => {
   console.log(result)
   expect(result).toEqual(1)
 
-  const testField: GraphQLField<any, any> = {
+  let testField: GraphQLField<any, any> = {
     name: 'testField',
     description: '@marker',
     type: GraphQLString,
@@ -51,6 +54,18 @@ test('parseMarker tests', () => {
   }
   result = parseMarker('marker', testField)
   expect(result).toEqual(true)
+
+  testField = {
+    name: 'testField',
+    description: undefined,
+    type: GraphQLString,
+    args: undefined,
+    extensions: undefined,
+    isDeprecated: false,
+    deprecationReason: undefined
+  }
+  result = parseMarker('marker', testField)
+  expect(result).toEqual(undefined)
 })
 
 test('stripAnnotations', () => {

--- a/tests/specs/metadata.ts
+++ b/tests/specs/metadata.ts
@@ -23,6 +23,14 @@ test('parse blank metadata', () => {
   expect(result).toEqual(true)
 })
 
+test('return undefined when no metadata', () => {
+  const field = setupField('This is a description')
+
+  const result = parseMetadata('test', field)
+
+  expect(result).toEqual(undefined)
+})
+
 test('validate invalid metadata', () => {
   const field = setupField(`This is a description
     @test here is some text that does not belong


### PR DESCRIPTION
An error was thrown when a field was undefined as the parse did not handle this. This change fixes this (added tests for it also).