### PR TITLE
Parse string metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+#### 0.7.0 (2020-06-23)
+
+* let users supply a string to `parseMetadata` to be parsed ([3d0df66](https://github.com/aerogear/graphql-metadata/commit/3d0df6615c1b90f8c7964dcf41bcbeab9f59a77c)
+
 #### 0.6.3 (2020-06-08)
 
-* remove deprecation warning from console ([11ea03a])(https://github.com/aerogear/graphql-metadata/commit/11ea03ae2215d487d86e554a7a3317fa9a5ba2e9)
+* remove deprecation warning from console ([11ea03a](https://github.com/aerogear/graphql-metadata/commit/11ea03ae2215d487d86e554a7a3317fa9a5ba2e9)
 
 #### 0.6.2 (2020-06-03)
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ const result = parseMetadata('db', field)
 // Returns true
 ```
 
+Or with a string:
+
+```js
+const result = parseMetadata('db', '@db(name: "users")')
+```
+
 ### [DEPRECATED] Annotations parsing
 
 Here is a very basic example with a `namespace` (here `'db'`) and a `description` that needs to be parsed:

--- a/tests/specs/annotations.ts
+++ b/tests/specs/annotations.ts
@@ -40,7 +40,6 @@ test('parseMarker tests', () => {
   result = parseMarker('marker', `
   This is a description
   @marker 1`)
-  console.log(result)
   expect(result).toEqual(1)
 
   let testField: GraphQLField<any, any> = {

--- a/tests/specs/metadata.ts
+++ b/tests/specs/metadata.ts
@@ -84,7 +84,23 @@ test('fail to parse metadata with missing closing tag', () => {
 test('fail to parse metadata with an undefined value', () => {
   const field = setupField('@invalid(reason: undefinedVariable)')
 
-  const result = parseMetadata('invalid', field)
+  const result = parseMetadata('valid', field)
+
+  expect(result).toBeUndefined()
+});
+
+test('parse metadata from string description', () => {
+  const description = '@valid(reason: "This is a valid way to parse metadata")'
+
+  const result = parseMetadata('valid', description)
+
+  expect(result).toEqual({
+    reason: 'This is a valid way to parse metadata'
+  })
+});
+
+test('return undefined when no annotation found', () => {
+  const result = parseMetadata('valid', '')
 
   expect(result).toBeUndefined()
 });


### PR DESCRIPTION
`parseMetadata` only allows you to pass an object, where it will then extract the description.

There will be use cases where someone just wants to parse the description field without having the field object.