### PR TITLE
build: include declaration files with package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/aerogear/graphql-metadata/#readme",
   "main": "dist/index.js",
-  "types": "types/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b",
     "watch": "tsc -w",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "declarationDir": "./types",
     "declaration": true,
     "target": "es2017",
     "module": "commonjs",


### PR DESCRIPTION
This PR bundles the type declarations with the compiled package and will be published to npm under graphql-metadata.