### PR TITLE
fix: use relative import path and use local `Maybe` type which wraps only allowed types

### DIFF
--- a/src/annotations/parseMarker.ts
+++ b/src/annotations/parseMarker.ts
@@ -1,7 +1,6 @@
 import safeEval from 'safe-eval'
-import { TypeOrDescription } from 'src/definitions'
+import { TypeOrDescription, Maybe } from '../definitions'
 import { getDescription } from '../util/getDescription';
-import Maybe from 'graphql/tsutils/Maybe';
 
 /**
  * Parse marker annotations.

--- a/src/annotations/parseMetadata.ts
+++ b/src/annotations/parseMetadata.ts
@@ -1,6 +1,5 @@
 import safeEval from 'safe-eval'
-import { TypeOrDescription } from 'src/definitions'
-import Maybe from 'graphql/tsutils/Maybe'
+import { TypeOrDescription, Maybe } from '../definitions'
 import { getDescription } from '../util/getDescription'
 
 /**

--- a/src/util/getDescription.ts
+++ b/src/util/getDescription.ts
@@ -1,5 +1,4 @@
-import { TypeOrDescription } from '../definitions'
-import Maybe from 'graphql/tsutils/Maybe';
+import { TypeOrDescription, Maybe } from '../definitions'
 
 /**
  * Helper to extract the description value from a possible GraphQL type


### PR DESCRIPTION
There were two issues which only presented themselves when type declarations started to be used:

1. `TypeOrDescription` was not being imported relative to the current file. This caused issue with type declaration files not being able to find the imported file.

2. The wrong `Maybe` util type was being used. The local `Maybe` wraps the elements that are allowed by `parseMetadata`, whereas the one being used was from GraphQL which allowed different types which are incompatible.

## Verification

You can use the dev version published for verification:

`npm install graphql-metadata@0.7.3-dev1`