### PR TITLE
chore(deps): remove the safe-eval package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,17 +25,16 @@
     "prepublishOnly": "yarn run test:all"
   },
   "dependencies": {
-    "chalk": "4.0.0",
-    "safe-eval": "0.4.1"
+    "vm2": "3.9.2"
   },
   "devDependencies": {
-    "graphql": "15.0.0",
     "@types/jest": "^25.2.3",
     "@typescript-eslint/eslint-plugin": "2.34.0",
     "@typescript-eslint/parser": "2.34.0",
     "eslint": "^5.12.1",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-node": "^8.0.1",
+    "graphql": "15.0.0",
     "jest": "26.0.1",
     "rimraf": "3.0.2",
     "ts-jest": "26.0.0",

--- a/src/annotations/parseAnnotations.ts
+++ b/src/annotations/parseAnnotations.ts
@@ -1,4 +1,4 @@
-import safeEval from 'safe-eval'
+import { safeEvaluate }  from '../util/safe-evaluate'
 
 
 /**
@@ -31,7 +31,7 @@ export function parseAnnotations (namespace: string, description: string) {
         const name = line.substr(0, separatorIndex).trim()
         const value = line.substr(separatorIndex + 1).trim()
         try {
-          obj[name] = safeEval(value)
+          obj[name] = safeEvaluate(value)
         } catch (e) {
           console.error(`Can't parse annotation ${line}: ${e.message}`)
         }

--- a/src/annotations/parseMarker.ts
+++ b/src/annotations/parseMarker.ts
@@ -1,4 +1,4 @@
-import safeEval from 'safe-eval'
+import { safeEvaluate }  from '../util/safe-evaluate'
 import { TypeOrDescription, Maybe } from '../definitions'
 import { getDescription } from '../util/getDescription';
 
@@ -38,13 +38,13 @@ export function parseMarker(marker: string, definition: Maybe<TypeOrDescription>
       const [key, value] = entry.split(':')
       if (key && value) {
         try {
-          obj[key.trim()] = safeEval(value)
+          obj[key.trim()] = safeEvaluate(value)
         } catch (e) {
           console.error(`Can't parse annotation ${line}: ${e.message}`)
         }
       } else if (key) {
         try {
-          obj = safeEval(key)
+          obj = safeEvaluate(key)
         } catch (e) {
           console.error(`Can't parse annotation ${line}: ${e.message}`)
         }

--- a/src/annotations/parseMetadata.ts
+++ b/src/annotations/parseMetadata.ts
@@ -1,4 +1,4 @@
-import safeEval from 'safe-eval'
+import { safeEvaluate }  from '../util/safe-evaluate'
 import { TypeOrDescription, Maybe } from '../definitions'
 import { getDescription } from '../util/getDescription'
 
@@ -59,7 +59,7 @@ export function parseMetadata(name: string, definition: Maybe<TypeOrDescription>
 
     let parsedContent: any;
     try {
-      parsedContent = safeEval(enclosedContent)
+      parsedContent = safeEvaluate(enclosedContent)
     } catch (e) {
       console.error(`Can't parse "@${name}" annotation${maybeOwner}: ${e.message}`)
     }

--- a/src/util/safe-evaluate.ts
+++ b/src/util/safe-evaluate.ts
@@ -1,0 +1,13 @@
+import  { VM } from 'vm2';
+
+export function safeEvaluate(value: string): Object {
+  const vm = new VM({
+    timeout: 1000 * 60, // timeout after a minute to avoid infite loops etc
+    sandbox: {
+      metadata: undefined // this will contain the result
+    }
+  });
+
+  vm.run(`metadata = ${value};`) // initialise the result in the script
+  return vm.sandbox.metadata;
+}


### PR DESCRIPTION
Fixes #28 

No test are failing with this (I assume they are extensive) /cc @craicoverflow  

I have used this poor man's benchmark script to verify that there is almost no perf impact:

```js
const  { VM } = require('vm2');
const safeEval = require('safe-eval');

function safeEvalVm2(value) {
  const vm = new VM({
    timeout: 1000 * 60,
    sandbox: {
      metadata: undefined
    }
  });

  vm.run(`metadata = ${value};`)
  return vm.sandbox.metadata;
}

function safeEvalDep(value) {
  return safeEval(value);
}

for (let i = 0; i < 10000; i++) {
  console.time("safeEvalDep" + i)
  safeEvalDep(`{first: "This is a very long string of undhsjdsjhgfdsgfhsgfhgsfdshgfhdsgfhdgshfgsdhgfhsgfhdsgfjgdshfgdshfgdsjfhdsgfgdshfgsffdhsjfhdsjfds-${i}", second: 1, third: "dhsjdhjshdjshdjshd", fourth: {fifth: "dsdsd", sixth: [1, 2, "3"]}}`)
  console.timeEnd("safeEvalDep" +i)
}


for (let i = 0; i < 10000; i++) {
  console.time("safeEvalVm2" + i)
  safeEvalVm2(`{first: "This is a very long string of undhsjdsjhgfdsgfhsgfhgsfdshgfhdsgfhdgshfgsdhgfhsgfhdsgfjgdshfgdshfgdsjfhdsgfgdshfgsffdhsjfhdsjfds-${i}", second: 1, third: "dhsjdhjshdjshdjshd", fourth: {fifth: "dsdsd", sixth: [1, 2, "3"]}}`)
  console.timeEnd("safeEvalVm2" +i)
}
```