### PR TITLE
fix: annotation detection not working when description contains several annotations with same prefix

### DIFF
--- a/src/annotations/parseMetadata.ts
+++ b/src/annotations/parseMetadata.ts
@@ -24,14 +24,28 @@ export function parseMetadata(name: string, definition: Maybe<TypeOrDescription>
   }
 
   if (description) {
-    const start = `@${name}`
+    const annotation = `@${name}`;
+    const regex = new RegExp(`${annotation}\\s*\\(.*\\)?$`);
+    const lines = description.split('\n');
+    let line: string;
 
-    let line = description.split('\n').map(line => line.trim())
-      .find(line => line.startsWith(start))
+    for (const rawLine of lines) {
+      const trimmed = rawLine.trim();
+      if (!trimmed.length) {
+        continue;
+      }
+
+      if (annotation === trimmed || regex.test(trimmed)) {
+        line = trimmed;
+        break;
+      }
+    }
+
     if (!line) {
       return undefined
     }
-    line = line.substr(start.length).trim()
+
+    line = line.substr(annotation.length).trim()
     if (line === '') {
       return true
     }

--- a/src/annotations/stripAnnotations.ts
+++ b/src/annotations/stripAnnotations.ts
@@ -2,10 +2,11 @@
  * @param {string?} description
  */
 export function stripAnnotations(description: string) {
-  if (description) {
-    let lines = description.split('\n')
-    lines = lines.filter(line => !line.trim().startsWith('@'))
-    description = lines.join('\n')
+  if (!description) {
+    return description;
   }
-  return description
+
+  return description.split('\n')
+  .filter(line => !line.trim().startsWith('@'))
+  .join('\n')
 }

--- a/tests/specs/metadata.ts
+++ b/tests/specs/metadata.ts
@@ -100,7 +100,32 @@ test('parse metadata from string description', () => {
 });
 
 test('return undefined when no annotation found', () => {
-  const result = parseMetadata('valid', '')
+  const result = parseMetadata('valid', '');
 
-  expect(result).toBeUndefined()
+  expect(result).toBeUndefined();
 });
+
+test('return undefined when annotation does not full match the given ', () => {
+  let result = parseMetadata('test', '@test-test');
+  expect(result).toBeUndefined();
+
+  result = parseMetadata('test', '@test_test');
+  expect(result).toBeUndefined();
+
+  result = parseMetadata('test', '@test_()');
+  expect(result).toBeUndefined();
+})
+
+
+test('matches right annotation when parsing description with several annotations having a common prefix', () => {
+  let result = parseMetadata('test-test',
+  `@test
+  @test-test(value: 1)`);
+
+  expect(result).toEqual({value: 1});
+
+  result = parseMetadata('test', `@test_test
+  @test(value: 2)
+  `);
+  expect(result).toEqual({ value: 2 });
+})


### PR DESCRIPTION
Fixes https://github.com/aerogear/graphql-metadata/issues/29