### PR TITLE
ci(release): add npm release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,7 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest] 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: "tagged-release"
+
+on:
+  release:
+    types: [released, prereleased]
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - name: Checkout master
+      uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Cache node_modules
+      id: cache-modules
+      uses: actions/cache@v1
+      with:
+        path: node_modules
+        key: ${{ matrix.node-version }}-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
+    - name: Install dependencies
+      if: steps.cache-modules.outputs.cache-hit != 'true'
+      run: yarn install
+    - name: Build
+      run: yarn build
+    - name: Lint
+      run: yarn lint
+    - name: Test Types
+      run: yarn test:types
+    - name: Test
+      run: yarn test
+
+  publish:
+    name: Publish
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache node_modules
+      id: cache-modules
+      uses: actions/cache@v1
+      with:
+        path: node_modules
+        key: 12.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
+    - name: Install dependencies
+      if: steps.cache-modules.outputs.cache-hit != 'true'
+      run: yarn install
+    
+    - name: Create .npmrc
+      run: echo "//registry.npmjs.org/:_authToken=${{secrets.NPM_AUTH_TOKEN}}" > ~/.npmrc
+    - name: Publish to npm
+      run: TAG=${GITHUB_REF#"refs/tags/"} PRE_RELEASE=${{github.event.release.prerelease}} npm run release:publish

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test": "jest",
     "test:types": "tsc",
     "test:all": "yarn run lint && yarn run test && yarn run test:types",
-    "prepublishOnly": "yarn run test:all"
+    "release:validate": "./scripts/validateRelease.sh",
+    "release:publish": "./scripts/publishRelease.sh"
   },
   "dependencies": {
     "vm2": "3.9.2"

--- a/release-guide.md
+++ b/release-guide.md
@@ -1,0 +1,39 @@
+# How to Release
+
+## Prerequisites
+
+GraphQL Metadata follows [semantic versioning](https://semver.org). Please ensure the release version you create follows this.
+
+## Stable release
+
+1. Create a new branch from master: `git checkout -b chore/release-x.x.x` (x.x.x represents the new version).
+2. Change the [package.json](https://github.com/aerogear/graphql-metadata/blob/master/package.json#L3) version to the new version.
+3. Create a commit: `chore(release): release version x.x.x`.
+4. Push your branch and create a pull request to master.
+5. Once merged, you can publish the release through [Git tagging](#git-tagging) or [GitHub](#releasing-through-github).
+
+## Pre-release
+
+If your a creating a pre-release, you do not need to update the `package.json`. To trigger a pre-release, append the version with `-xxx`; for example: `1.0.0-beta1`. You can do this by following the [Git tagging](#git-tagging) or [GitHub](#releasing-through-github) steps below.
+
+## Git tagging
+
+1. `git tag x.x.x` (x.x.x being the new version).
+2. `git push origin x.x.x`.
+3. Go to the release tag in GitHub and click _Edit tag_.
+4. Update the _Release title_ to `x.x.x`.
+5. If it is a pre-release, tick the _This is a pre-release_ checkbox.
+6. In the description, add the release notes from the [CHANGELOG](./CHANGELOG.md).
+7. The release workflow will be triggered. You can monitor progress in the [GitHub Actions view](https://github.com/aerogear/graphql-metadata/actions?query=workflow%3ACI).
+
+See [Git tagging](https://git-scm.com/book/en/v2/Git-Basics-Tagging) for a complete guide on this process.
+
+## Releasing through GitHub
+
+1. Create a new release through the [releases](https://github.com/aerogear/graphql-metadata/releases) view.
+2. Set the _Tag version_ to your release version: `x.x.x`.
+3. Set the _Release title_ to your release version: `x.x.x`.
+4. If it is a pre-release, tick the _This is a pre-release_ checkbox.
+5. In the description, add the release notes from the [CHANGELOG](./CHANGELOG.md).
+
+See [creating releases through GitHub](https://docs.github.com/en/enterprise/2.13/user/articles/creating-releases) for the official guide on this process.

--- a/scripts/publishRelease.sh
+++ b/scripts/publishRelease.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# explicit declaration that this script needs a $TAG variable passed in e.g TAG=1.2.3 ./script.sh
+TAG=$TAG
+
+RELEASE_SYNTAX='^[0-9]+\.[0-9]+\.[0-9]+$'
+PRERELEASE_SYNTAX='^[0-9]+\.[0-9]+\.[0-9]+(-.+)+$'
+
+if [ ! "$CI" = true ]; then
+  echo "Warning: this script should not be run outside of the CI"
+  echo "If you really need to run this script, you can use"
+  echo "CI=true ./scripts/publishRelease.sh"
+  exit 1
+fi
+
+if [[ "$PRE_RELEASE" = true || "$(echo $TAG | grep -E $PRERELEASE_SYNTAX)" == "$TAG" ]]; then
+  npm version $TAG --no-push --no-push --no-git-tag-version --exact --ignore-changes -y 
+  echo "publishing a new pre release: $TAG" 
+  npm publish --tag next
+elif [[ "$(echo $TAG | grep -E $RELEASE_SYNTAX)" == "$TAG" ]]; then
+  TAG=$TAG npm run release:validate
+  echo "publishing a new release: $TAG"
+  npm publish
+else
+  echo "Error: the tag $TAG is not valid. exiting..."
+  exit 1
+fi

--- a/scripts/validateRelease.sh
+++ b/scripts/validateRelease.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# explicit declaration that this script needs a $TAG variable passed in e.g TAG=1.2.3 ./script.sh
+TAG=$TAG
+TAG_SYNTAX='^[0-9]+\.[0-9]+\.[0-9]+(-.+)*$'
+
+# get version found in package.json. This is the source of truth
+PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')
+
+# validate tag has format x.y.z
+if [[ "$(echo $TAG | grep -E $TAG_SYNTAX)" == "" ]]; then
+  echo "tag $TAG is invalid. Must be in the format x.y.z or x.y.z-SOME_TEXT"
+  exit 1
+fi
+
+# validate that TAG == version found in package.json
+if [[ $TAG != $PACKAGE_VERSION ]]; then
+  echo "tag $TAG is not the same as package version found in package.json $PACKAGE_VERSION"
+  exit 1
+fi


### PR DESCRIPTION
This PR semi-automates stable releases and fully automates pre-releases.

The workflow is triggered on the following events:

- When a new tag is pushed with Git (see [Git tagging](https://git-scm.com/book/en/v2/Git-Basics-Tagging))
- When a release is created in [GitHub releases](https://github.com/aerogear/graphql-metadata/releases)

A pre-release is published when it is marked `pre-release` through GitHub releases, or if it the tag follows the format: `1.2.3-xxx`. With a pre-release, you do not need to bump the version in the `package.json`.

With a stable release, a prerequisite is that you bump the `version` in the `package.json` to the version you plan to release, otherwise it will fail.

## Verification

The closest thing you can get to verifying this is by checking out my fork: https://github.com/craicoverflow/graphql-metadata/actions?query=workflow%3ACI and a test package I created on npm: https://www.npmjs.com/package/graphql-metadata-test

## Tasks

- [x] Automate releases with GitHub Actions
- [x] Add a [release guide](https://github.com/aerogear/graphql-metadata/blob/a86748c24c50d71eca72de43f6f0a17939c4898e/release-guide.md)